### PR TITLE
Add Welcome to the Moon

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ A selection of major game studios, publishers, etc. using GitHub:
 * [Green Mahjong](https://github.com/danbeck/green-mahjong) - Solitaire mahjong game done in HTML/CSS/JS.
 * [Kriegspiel](https://github.com/binarymax/kriegspiel) - The game of imperfect information, the Kriegspiel chess variant.
 * [Lichess](https://github.com/ornicar/lila) - Free chess game using HTML5 & websockets, built with Scala, Play 2.1, MongoDB and Elasticsearch. [Play it now!](http://lichess.org/)
+* [Welcome To The Moon Companion](https://github.com/Cheshiriks/Welcome-To-The-Moon-Companion) - A companion app for independently completing all 8 scenarios of the board game Welcome to the Moon. [Play it now!](https://cheshiriks.github.io/WelcomeToTheMoonCompanion/)
 
 
 ## Arcade


### PR DESCRIPTION
Unity project for the Welcome to the Moon board game.

[Welcome-To-The-Moon-Companion](https://github.com/Cheshiriks/Welcome-To-The-Moon-Companion) is a companion app for independently completing all 8 scenarios of the board game Welcome to the Moon.

WelcomeToTheMoon

![255353003-fec51a08-5830-4656-9c9a-063b6c2cf209](https://github.com/user-attachments/assets/19b2d7db-a478-4b15-b888-e0d54afb223f)
