### PR TITLE
feat: add DagorEngine to frameworks list

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ A selection of major game studios, publishers, etc.:
 * [Cocos2d-x](https://github.com/cocos2d/cocos2d-x) - Multi-platform framework for building 2d games, interactive books, demos and other graphical applications. It is based on cocos2d-iphone, but instead of using Objective-C, it uses C++. It works on iOS, Android, Windows Phone, OS X, Windows and Linux.
 * [Crafty](https://github.com/craftyjs/Crafty) - JavaScript game library that can help you create games in a structured way.
 * [CutJS](https://github.com/piqnt/cutjs) - Lightweight and fast 2D HTML5 rendering engine for cross-platform game development.
-* [DagorEngine](https://github.com/GaijinEntertainment/DagorEngine) - Open game engine and toolset from Gaijin Entertainment.
+* [Dagor Engine](https://github.com/GaijinEntertainment/DagorEngine) - Open-source game engine and toolset from Gaijin Entertainment.
 * [Dash](https://github.com/Circular-Studios/Dash) - Free and open 3D game engine written in D.
 * [Duality](https://github.com/AdamsLair/duality) - 2D Game Development Framework.
 * [EaselJS](https://github.com/CreateJS/EaselJS/) - Library to make working with the Canvas element easier.

--- a/README.md
+++ b/README.md
@@ -573,6 +573,7 @@ A selection of major game studios, publishers, etc.:
 * [Cocos2d-x](https://github.com/cocos2d/cocos2d-x) - Multi-platform framework for building 2d games, interactive books, demos and other graphical applications. It is based on cocos2d-iphone, but instead of using Objective-C, it uses C++. It works on iOS, Android, Windows Phone, OS X, Windows and Linux.
 * [Crafty](https://github.com/craftyjs/Crafty) - JavaScript game library that can help you create games in a structured way.
 * [CutJS](https://github.com/piqnt/cutjs) - Lightweight and fast 2D HTML5 rendering engine for cross-platform game development.
+* [DagorEngine](https://github.com/GaijinEntertainment/DagorEngine) - Open game engine and toolset from Gaijin Entertainment.
 * [Dash](https://github.com/Circular-Studios/Dash) - Free and open 3D game engine written in D.
 * [Duality](https://github.com/AdamsLair/duality) - 2D Game Development Framework.
 * [EaselJS](https://github.com/CreateJS/EaselJS/) - Library to make working with the Canvas element easier.


### PR DESCRIPTION
Adds DagorEngine to the Frameworks/Engines/Libraries section.

Closes #50.