### PR TITLE
feat: add native VR games section

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ A selection of major game studios, publishers, etc.:
 ## VR
 
 * [270Tetris](https://github.com/dschoeneborn/270Tetris) - VR take on classic Tetris. Written in Unity.
-* [3D-Modeling-VR](https://github.com/mari-rmrz/3D-Modeling-VR) - Portfolio and development journal for a VR game project. Written in Unity.
+* [3D Modeling VR](https://github.com/mari-rmrz/3D-Modeling-VR) - Portfolio and development journal for a VR game project. Written in Unity.
 * [adaptive-vr-game](https://github.com/PedroBarcha/adaptive-vr-game) - Educational Android VR game designed for people with neurodevelopmental disorders. Written in Unity.
 * [AbstractInvadersVR](https://github.com/guneyozsan/AbstractInvadersVR) - VR shooter created for Global Game Jam 2017. Written in Unity.
 * [AirAttack](https://github.com/Vova-SH/AirAttack) - Gear VR game created for the 2018 VR 360 School Contest. Written in Unity.
@@ -461,39 +461,39 @@ A selection of major game studios, publishers, etc.:
 * [CatcherVRGame](https://github.com/nntdoan/CatcherVRGame) - VR game project. Written in Unity.
 * [cardboard](https://github.com/1j01/cardboard) - Early browser-based VR tunnel game experiment. Written in HTML/JavaScript. [Play it now!](http://1j01.github.io/cardboard/)
 * [CaveTerrors-VR](https://github.com/Z-ANESaber/CaveTerrors-VR) - Minecraft-inspired horror game with VR support. Written in Unity.
-* [Cindy-s-Bad-Luck-BLS-VR](https://github.com/ClaudiaRaffaelli/Cindy-s-Bad-Luck-BLS-VR) - VR game for learning basic life-support maneuvers. Written in Unity.
-* [CloudeLand-project](https://github.com/GigaFlopsis/CloudeLand-project) - CloudLand VR game for Daydream and Cardboard. Written in Unity.
-* [Cuteness-Overdose-Vr](https://github.com/hendzormati/Cuteness-Overdose-Vr) - Meta Quest 3 VR game about smashing cupcakes in a shifting pastel-horror setting. Written in Unity.
+* [Cindy's Bad Luck](https://github.com/ClaudiaRaffaelli/Cindy-s-Bad-Luck-BLS-VR) - VR game for learning basic life-support maneuvers. Written in Unity.
+* [CloudLand](https://github.com/GigaFlopsis/CloudeLand-project) - CloudLand VR game for Daydream and Cardboard. Written in Unity.
+* [Cuteness Overdose VR](https://github.com/hendzormati/Cuteness-Overdose-Vr) - Meta Quest 3 VR game about smashing cupcakes in a shifting pastel-horror setting. Written in Unity.
 * [Dodge-Ball](https://github.com/SarathChandraKaza/Dodge-Ball) - Single-player dodgeball game for Oculus devices. Written in Unity.
 * [EcoHome](https://github.com/htl-leo-itp-2325-4-5BHITM/EcoHome) - Unity VR game about everyday sustainability. Written in Unity. [Play it now!](https://ecohome.itch.io/ecohome)
-* [Escape-the-Room](https://github.com/Cranesec/Escape-the-Room) - Immersive mystery VR escape-room game. Written in Python.
-* [Final-VR-Project](https://github.com/YesItsSKM/Final-VR-Project) - Final MSc VR/AR project. Written in Unity.
+* [Escape the Room](https://github.com/Cranesec/Escape-the-Room) - Immersive mystery VR escape-room game. Written in Python.
+* [Final VR Project](https://github.com/YesItsSKM/Final-VR-Project) - Final MSc VR/AR project. Written in Unity.
 * [GodescXR](https://github.com/sorokivski/GodescXR) - VR game project. Written in Godot. [Play it now!](https://sorokivski.itch.io/godescxr)
 * [Graveyard-Roller-Coaster](https://github.com/ShutovKS/Graveyard-Roller-Coaster) - Short cinematic VR roller-coaster game set in a graveyard. Written in Unity.
-* [HandTracked-Virtual-Body-VR](https://github.com/YesItsSKM/HandTracked-Virtual-Body-VR) - VR game prototype focused on hand-tracked embodiment and IK body interaction. Written in Unity.
+* [Hand-Tracked Virtual Body for VR Experiences](https://github.com/YesItsSKM/HandTracked-Virtual-Body-VR) - VR game prototype focused on hand-tracked embodiment and IK body interaction. Written in Unity.
 * [invaderInVR](https://github.com/fgadea/invaderInVR) - Unity VR game inspired by classic Space Invaders. Written in Unity.
 * [king-of-kitchen](https://github.com/maxolib/king-of-kitchen) - VR kitchen game project. Written in Unity.
 * [MarcoSmiles-RhythmGame](https://github.com/UmbertoDellaMonica/MarcoSmiles-RhythmGame) - VR rhythm platformer using Unity hand tracking and a FastAPI backend. Written in Unity and FastAPI.
 * [MechaRacer](https://github.com/chubozeko/MechaRacer) - VR racing game about driving a toy car and hitting mech robots. Written in Unity.
-* [mern-vrgame](https://github.com/shamahoque/mern-vrgame) - MERN-stack VR game for the web. Written in JavaScript (MERN). [Play it now!](http://vrgame2.mernbook.com)
+* [MERN VR Game 2.0](https://github.com/shamahoque/mern-vrgame) - MERN-stack VR game for the web. Written in JavaScript (MERN). [Play it now!](http://vrgame2.mernbook.com)
 * [mind-remnants](https://github.com/KatyaZubareva/mind-remnants) - VR game project. Written in Unity.
 * [Mission_Impossible](https://github.com/Shawn0791/Mission_Impossible) - Giant-room-concept VR game. Written in Unity. [Play it now!](https://shawnjobseeking.itch.io/mission-impossible-vr)
 * [Modern-Cupid-VR](https://github.com/sarasmajic/Modern-Cupid-VR) - VR game built in Unity. Written in Unity.
 * [pigpoppa](https://github.com/elocnatsirt/pigpoppa) - VR game created for Godot Wild Jam #22. Written in Godot. [Play it now!](https://elocnat.itch.io/pigpoppa)
-* [Puzzle-Vault-Expedition](https://github.com/hxqqqqqqqq/Puzzle-Vault-Expedition) - Escape-room puzzle game project. Written in web technologies.
-* [RocketMan-a-VR-videogame-created-with-Unity](https://github.com/EliaFantini/RocketMan-a-VR-videogame-created-with-Unity) - Virtual reality escape-room-like game for Oculus Quest built with Unity. Written in Unity.
+* [Mindscape: The Cognitive Labyrinth](https://github.com/hxqqqqqqqq/Puzzle-Vault-Expedition) - Escape-room puzzle game project. Written in web technologies.
+* [RocketMan](https://github.com/EliaFantini/RocketMan-a-VR-videogame-created-with-Unity) - Virtual reality escape-room-like game for Oculus Quest built with Unity. Written in Unity.
 * [Terminal](https://github.com/danielcolinjames/Terminal) - Virtual reality puzzle game built in Unity. Written in Unity.
 * [The-Art-Inspector](https://github.com/chubozeko/The-Art-Inspector) - VR game about identifying and organizing real art pieces from fake ones. Written in Unity.
-* [Tiny-Winter-Scare-VR](https://github.com/JeromeTDev/Tiny-Winter-Scare-VR) - Small VR jump-scare game built in Unity on Linux. Written in Unity.
-* [UMN-VR-Quest-2-App](https://github.com/UMN-VR/UMN-VR-Quest-2-App) - Open-sourced proof of concept for a photogrammetry-based Quest 2 VR experience. Written in Unity and WebXR. [Play it now!](https://umn-vr.github.io/WebGL_Demo/)
-* [valentines-vr](https://github.com/urish/valentines-vr) - Small VR heart-collecting game built with A-Frame. Written in A-Frame. [Play it now!](https://urish.github.io/valentines-vr/)
-* [VR-AR-Game](https://github.com/alisatodorova/VR-AR-Game) - Unity game created for a virtual and augmented reality course. Written in Unity.
-* [VR-Escape-Room](https://github.com/AB-Pop/VR-Escape-Room) - Virtual escape-room project made for school. Written in Unity.
-* [vr-game](https://github.com/agrawalTanish/vr-game) - Interactive browser-based VR game experience with responsive UI and real-time interaction. Written in HTML/JavaScript. [Play it now!](https://tanishvrgame.netlify.app/)
+* [Tiny Winter Scare VR](https://github.com/JeromeTDev/Tiny-Winter-Scare-VR) - Small VR jump-scare game built in Unity on Linux. Written in Unity.
+* [UMN VR Quest 2 Photogrammetry Demo](https://github.com/UMN-VR/UMN-VR-Quest-2-App) - Open-sourced proof of concept for a photogrammetry-based Quest 2 VR experience. Written in Unity and WebXR. [Play it now!](https://umn-vr.github.io/WebGL_Demo/)
+* [VORD](https://github.com/urish/valentines-vr) - Small VR heart-collecting game built with A-Frame. Written in A-Frame. [Play it now!](https://urish.github.io/valentines-vr/)
+* [VR AR Game](https://github.com/alisatodorova/VR-AR-Game) - Unity game created for a virtual and augmented reality course. Written in Unity.
+* [VR Escape Room](https://github.com/AB-Pop/VR-Escape-Room) - Virtual escape-room project made for school. Written in Unity.
+* [VR Game](https://github.com/agrawalTanish/vr-game) - Interactive browser-based VR game experience with responsive UI and real-time interaction. Written in HTML/JavaScript. [Play it now!](https://tanishvrgame.netlify.app/)
 * [vr-gardengame](https://github.com/faadil1999/vr-gardengame) - VR garden game project. Written in Unity.
-* [VR-math-game](https://github.com/Robin-qwerty/VR-math-game) - VR math game for Meta Quest 2. Written in Unity.
+* [VR Math Shooter](https://github.com/Robin-qwerty/VR-math-game) - VR math game for Meta Quest 2. Written in Unity.
 * [VR-Wheelchair-Ping-Pong](https://github.com/PaulEdwardMurariu/VR-Wheelchair-Ping-Pong) - VR ping-pong game for wheelchair users. Written in Unity.
-* [vr-war-drum](https://github.com/kahogeoff/vr-war-drum) - VR rhythm game inspired by Taiko No Tatsujin and Taikojiro. Written in Unity.
+* [VR War Drum](https://github.com/kahogeoff/vr-war-drum) - VR rhythm game inspired by Taiko No Tatsujin and Taikojiro. Written in Unity.
 
 ## Others
 

--- a/README.md
+++ b/README.md
@@ -482,7 +482,6 @@ A selection of major game studios, publishers, etc.:
 * [pigpoppa](https://github.com/elocnatsirt/pigpoppa) - VR game created for Godot Wild Jam #22. Written in Godot. [Play it now!](https://elocnat.itch.io/pigpoppa)
 * [Puzzle-Vault-Expedition](https://github.com/hxqqqqqqqq/Puzzle-Vault-Expedition) - Escape-room puzzle game project. Written in web technologies.
 * [RocketMan-a-VR-videogame-created-with-Unity](https://github.com/EliaFantini/RocketMan-a-VR-videogame-created-with-Unity) - Virtual reality escape-room-like game for Oculus Quest built with Unity. Written in Unity.
-* [snowden](https://github.com/miozilla/snowden) - VR game project. Written in SQL.
 * [Terminal](https://github.com/danielcolinjames/Terminal) - Virtual reality puzzle game built in Unity. Written in Unity.
 * [The-Art-Inspector](https://github.com/chubozeko/The-Art-Inspector) - VR game about identifying and organizing real art pieces from fake ones. Written in Unity.
 * [Tiny-Winter-Scare-VR](https://github.com/JeromeTDev/Tiny-Winter-Scare-VR) - Small VR jump-scare game built in Unity on Linux. Written in Unity.

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ A selection of major game studios, publishers, etc.:
 
 * [270Tetris](https://github.com/dschoeneborn/270Tetris) - VR take on classic Tetris. Written in Unity.
 * [3D Modeling VR](https://github.com/mari-rmrz/3D-Modeling-VR) - Portfolio and development journal for a VR game project. Written in Unity.
-* [adaptive-vr-game](https://github.com/PedroBarcha/adaptive-vr-game) - Educational Android VR game designed for people with neurodevelopmental disorders. Written in Unity.
+* [Adaptive Virtual Reality Educational Game](https://github.com/PedroBarcha/adaptive-vr-game) - Educational Android VR game designed for people with neurodevelopmental disorders. Written in Unity.
 * [AbstractInvadersVR](https://github.com/guneyozsan/AbstractInvadersVR) - VR shooter created for Global Game Jam 2017. Written in Unity.
 * [AirAttack](https://github.com/Vova-SH/AirAttack) - Gear VR game created for the 2018 VR 360 School Contest. Written in Unity.
 * [Arcadium](https://github.com/NeonVhenan/Arcadium) - VR app/game created as part of an MSc course. Written in Unity.
@@ -479,7 +479,7 @@ A selection of major game studios, publishers, etc.:
 * [mind-remnants](https://github.com/KatyaZubareva/mind-remnants) - VR game project. Written in Unity.
 * [Mission_Impossible](https://github.com/Shawn0791/Mission_Impossible) - Giant-room-concept VR game. Written in Unity. [Play it now!](https://shawnjobseeking.itch.io/mission-impossible-vr)
 * [Modern-Cupid-VR](https://github.com/sarasmajic/Modern-Cupid-VR) - VR game built in Unity. Written in Unity.
-* [pigpoppa](https://github.com/elocnatsirt/pigpoppa) - VR game created for Godot Wild Jam #22. Written in Godot. [Play it now!](https://elocnat.itch.io/pigpoppa)
+* [Pig Poppa](https://github.com/elocnatsirt/pigpoppa) - VR game created for Godot Wild Jam #22. Written in Godot. [Play it now!](https://elocnat.itch.io/pigpoppa)
 * [Mindscape: The Cognitive Labyrinth](https://github.com/hxqqqqqqqq/Puzzle-Vault-Expedition) - Escape-room puzzle game project. Written in web technologies.
 * [RocketMan](https://github.com/EliaFantini/RocketMan-a-VR-videogame-created-with-Unity) - Virtual reality escape-room-like game for Oculus Quest built with Unity. Written in Unity.
 * [Terminal](https://github.com/danielcolinjames/Terminal) - Virtual reality puzzle game built in Unity. Written in Unity.

--- a/README.md
+++ b/README.md
@@ -452,18 +452,48 @@ A selection of major game studios, publishers, etc.:
 
 ## VR
 
+* [270Tetris](https://github.com/dschoeneborn/270Tetris) - VR take on classic Tetris.
+* [3D-Modeling-VR](https://github.com/mari-rmrz/3D-Modeling-VR) - Portfolio and development journal for a VR game project.
 * [adaptive-vr-game](https://github.com/PedroBarcha/adaptive-vr-game) - Educational Android VR game designed for people with neurodevelopmental disorders.
 * [AbstractInvadersVR](https://github.com/guneyozsan/AbstractInvadersVR) - VR shooter created for Global Game Jam 2017.
+* [AirAttack](https://github.com/Vova-SH/AirAttack) - Gear VR game created for the 2018 VR 360 School Contest.
+* [Arcadium](https://github.com/NeonVhenan/Arcadium) - VR app/game created as part of an MSc course.
+* [CatcherVRGame](https://github.com/nntdoan/CatcherVRGame) - VR game project.
+* [cardboard](https://github.com/1j01/cardboard) - Early browser-based VR tunnel game experiment. [Play it now!](http://1j01.github.io/cardboard/)
 * [CaveTerrors-VR](https://github.com/Z-ANESaber/CaveTerrors-VR) - Minecraft-inspired horror game with VR support.
 * [Cindy-s-Bad-Luck-BLS-VR](https://github.com/ClaudiaRaffaelli/Cindy-s-Bad-Luck-BLS-VR) - VR game for learning basic life-support maneuvers.
+* [CloudeLand-project](https://github.com/GigaFlopsis/CloudeLand-project) - CloudLand VR game for Daydream and Cardboard.
+* [Cuteness-Overdose-Vr](https://github.com/hendzormati/Cuteness-Overdose-Vr) - Meta Quest 3 VR game about smashing cupcakes in a shifting pastel-horror setting.
+* [Dodge-Ball](https://github.com/SarathChandraKaza/Dodge-Ball) - Single-player dodgeball game for Oculus devices.
 * [EcoHome](https://github.com/htl-leo-itp-2325-4-5BHITM/EcoHome) - Unity VR game about everyday sustainability. [Play it now!](https://ecohome.itch.io/ecohome)
+* [Escape-the-Room](https://github.com/Cranesec/Escape-the-Room) - Immersive mystery VR escape-room game.
+* [Final-VR-Project](https://github.com/YesItsSKM/Final-VR-Project) - Final MSc VR/AR project.
+* [GodescXR](https://github.com/sorokivski/GodescXR) - VR game project. [Play it now!](https://sorokivski.itch.io/godescxr)
 * [Graveyard-Roller-Coaster](https://github.com/ShutovKS/Graveyard-Roller-Coaster) - Short cinematic VR roller-coaster game set in a graveyard.
+* [HandTracked-Virtual-Body-VR](https://github.com/YesItsSKM/HandTracked-Virtual-Body-VR) - VR game prototype focused on hand-tracked embodiment and IK body interaction.
 * [invaderInVR](https://github.com/fgadea/invaderInVR) - Unity VR game inspired by classic Space Invaders.
+* [king-of-kitchen](https://github.com/maxolib/king-of-kitchen) - VR kitchen game project.
 * [MarcoSmiles-RhythmGame](https://github.com/UmbertoDellaMonica/MarcoSmiles-RhythmGame) - VR rhythm platformer using Unity hand tracking and a FastAPI backend.
 * [MechaRacer](https://github.com/chubozeko/MechaRacer) - VR racing game about driving a toy car and hitting mech robots.
 * [mern-vrgame](https://github.com/shamahoque/mern-vrgame) - MERN-stack VR game for the web. [Play it now!](http://vrgame2.mernbook.com)
+* [mind-remnants](https://github.com/KatyaZubareva/mind-remnants) - VR game project.
+* [Mission_Impossible](https://github.com/Shawn0791/Mission_Impossible) - Giant-room-concept VR game. [Play it now!](https://shawnjobseeking.itch.io/mission-impossible-vr)
+* [Modern-Cupid-VR](https://github.com/sarasmajic/Modern-Cupid-VR) - VR game built in Unity.
+* [pigpoppa](https://github.com/elocnatsirt/pigpoppa) - VR game created for Godot Wild Jam #22. [Play it now!](https://elocnat.itch.io/pigpoppa)
+* [Puzzle-Vault-Expedition](https://github.com/hxqqqqqqqq/Puzzle-Vault-Expedition) - Escape-room puzzle game project.
+* [RocketMan-a-VR-videogame-created-with-Unity](https://github.com/EliaFantini/RocketMan-a-VR-videogame-created-with-Unity) - Virtual reality escape-room-like game for Oculus Quest built with Unity.
+* [snowden](https://github.com/miozilla/snowden) - VR game project.
+* [Terminal](https://github.com/danielcolinjames/Terminal) - Virtual reality puzzle game built in Unity.
 * [The-Art-Inspector](https://github.com/chubozeko/The-Art-Inspector) - VR game about identifying and organizing real art pieces from fake ones.
 * [Tiny-Winter-Scare-VR](https://github.com/JeromeTDev/Tiny-Winter-Scare-VR) - Small VR jump-scare game built in Unity on Linux.
+* [UMN-VR-Quest-2-App](https://github.com/UMN-VR/UMN-VR-Quest-2-App) - Open-sourced proof of concept for a photogrammetry-based Quest 2 VR experience.
+* [valentines-vr](https://github.com/urish/valentines-vr) - Small VR heart-collecting game built with A-Frame. [Play it now!](https://urish.github.io/valentines-vr/)
+* [VR-AR-Game](https://github.com/alisatodorova/VR-AR-Game) - Unity game created for a virtual and augmented reality course.
+* [VR-Escape-Room](https://github.com/AB-Pop/VR-Escape-Room) - Virtual escape-room project made for school.
+* [vr-game](https://github.com/agrawalTanish/vr-game) - Interactive browser-based VR game experience with responsive UI and real-time interaction. [Play it now!](https://tanishvrgame.netlify.app/)
+* [vr-gardengame](https://github.com/faadil1999/vr-gardengame) - VR garden game project.
+* [VR-math-game](https://github.com/Robin-qwerty/VR-math-game) - VR math game for Meta Quest 2.
+* [VR-Wheelchair-Ping-Pong](https://github.com/PaulEdwardMurariu/VR-Wheelchair-Ping-Pong) - VR ping-pong game for wheelchair users.
 * [vr-war-drum](https://github.com/kahogeoff/vr-war-drum) - VR rhythm game inspired by Taiko No Tatsujin and Taikojiro.
 
 ## Others

--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ A selection of major game studios, publishers, etc.:
 * [270Tetris](https://github.com/dschoeneborn/270Tetris) - VR take on classic Tetris. Written in Unity.
 * [3D Modeling VR](https://github.com/mari-rmrz/3D-Modeling-VR) - Portfolio and development journal for a VR game project. Written in Unity.
 * [Adaptive Virtual Reality Educational Game](https://github.com/PedroBarcha/adaptive-vr-game) - Educational Android VR game designed for people with neurodevelopmental disorders. Written in Unity.
-* [AbstractInvadersVR](https://github.com/guneyozsan/AbstractInvadersVR) - VR shooter created for Global Game Jam 2017. Written in Unity.
+* [Abstract Invaders VR](https://github.com/guneyozsan/AbstractInvadersVR) - VR shooter created for Global Game Jam 2017. Written in Unity.
 * [AirAttack](https://github.com/Vova-SH/AirAttack) - Gear VR game created for the 2018 VR 360 School Contest. Written in Unity.
 * [Arcadium](https://github.com/NeonVhenan/Arcadium) - VR app/game created as part of an MSc course. Written in Unity.
 * [CatcherVRGame](https://github.com/nntdoan/CatcherVRGame) - VR game project. Written in Unity.
@@ -469,21 +469,21 @@ A selection of major game studios, publishers, etc.:
 * [Escape the Room](https://github.com/Cranesec/Escape-the-Room) - Immersive mystery VR escape-room game. Written in Python.
 * [Final VR Project](https://github.com/YesItsSKM/Final-VR-Project) - Final MSc VR/AR project. Written in Unity.
 * [GodescXR](https://github.com/sorokivski/GodescXR) - VR game project. Written in Godot. [Play it now!](https://sorokivski.itch.io/godescxr)
-* [Graveyard-Roller-Coaster](https://github.com/ShutovKS/Graveyard-Roller-Coaster) - Short cinematic VR roller-coaster game set in a graveyard. Written in Unity.
+* [Graveyard Roller Coaster](https://github.com/ShutovKS/Graveyard-Roller-Coaster) - Short cinematic VR roller-coaster game set in a graveyard. Written in Unity.
 * [Hand-Tracked Virtual Body for VR Experiences](https://github.com/YesItsSKM/HandTracked-Virtual-Body-VR) - VR game prototype focused on hand-tracked embodiment and IK body interaction. Written in Unity.
 * [invaderInVR](https://github.com/fgadea/invaderInVR) - Unity VR game inspired by classic Space Invaders. Written in Unity.
-* [king-of-kitchen](https://github.com/maxolib/king-of-kitchen) - VR kitchen game project. Written in Unity.
+* [King of Kitchen](https://github.com/maxolib/king-of-kitchen) - VR kitchen game project. Written in Unity.
 * [MarcoSmiles-RhythmGame](https://github.com/UmbertoDellaMonica/MarcoSmiles-RhythmGame) - VR rhythm platformer using Unity hand tracking and a FastAPI backend. Written in Unity and FastAPI.
 * [MechaRacer](https://github.com/chubozeko/MechaRacer) - VR racing game about driving a toy car and hitting mech robots. Written in Unity.
 * [MERN VR Game 2.0](https://github.com/shamahoque/mern-vrgame) - MERN-stack VR game for the web. Written in JavaScript (MERN). [Play it now!](http://vrgame2.mernbook.com)
 * [mind-remnants](https://github.com/KatyaZubareva/mind-remnants) - VR game project. Written in Unity.
-* [Mission_Impossible](https://github.com/Shawn0791/Mission_Impossible) - Giant-room-concept VR game. Written in Unity. [Play it now!](https://shawnjobseeking.itch.io/mission-impossible-vr)
-* [Modern-Cupid-VR](https://github.com/sarasmajic/Modern-Cupid-VR) - VR game built in Unity. Written in Unity.
+* [Mission: Impossible](https://github.com/Shawn0791/Mission_Impossible) - Giant-room-concept VR game. Written in Unity. [Play it now!](https://shawnjobseeking.itch.io/mission-impossible-vr)
+* [Modern Cupid](https://github.com/sarasmajic/Modern-Cupid-VR) - VR game built in Unity. Written in Unity.
 * [Pig Poppa](https://github.com/elocnatsirt/pigpoppa) - VR game created for Godot Wild Jam #22. Written in Godot. [Play it now!](https://elocnat.itch.io/pigpoppa)
 * [Mindscape: The Cognitive Labyrinth](https://github.com/hxqqqqqqqq/Puzzle-Vault-Expedition) - Escape-room puzzle game project. Written in web technologies.
 * [RocketMan](https://github.com/EliaFantini/RocketMan-a-VR-videogame-created-with-Unity) - Virtual reality escape-room-like game for Oculus Quest built with Unity. Written in Unity.
 * [Terminal](https://github.com/danielcolinjames/Terminal) - Virtual reality puzzle game built in Unity. Written in Unity.
-* [The-Art-Inspector](https://github.com/chubozeko/The-Art-Inspector) - VR game about identifying and organizing real art pieces from fake ones. Written in Unity.
+* [The Art Inspector](https://github.com/chubozeko/The-Art-Inspector) - VR game about identifying and organizing real art pieces from fake ones. Written in Unity.
 * [Tiny Winter Scare VR](https://github.com/JeromeTDev/Tiny-Winter-Scare-VR) - Small VR jump-scare game built in Unity on Linux. Written in Unity.
 * [UMN VR Quest 2 Photogrammetry Demo](https://github.com/UMN-VR/UMN-VR-Quest-2-App) - Open-sourced proof of concept for a photogrammetry-based Quest 2 VR experience. Written in Unity and WebXR. [Play it now!](https://umn-vr.github.io/WebGL_Demo/)
 * [VORD](https://github.com/urish/valentines-vr) - Small VR heart-collecting game built with A-Frame. Written in A-Frame. [Play it now!](https://urish.github.io/valentines-vr/)
@@ -492,7 +492,7 @@ A selection of major game studios, publishers, etc.:
 * [VR Game](https://github.com/agrawalTanish/vr-game) - Interactive browser-based VR game experience with responsive UI and real-time interaction. Written in HTML/JavaScript. [Play it now!](https://tanishvrgame.netlify.app/)
 * [vr-gardengame](https://github.com/faadil1999/vr-gardengame) - VR garden game project. Written in Unity.
 * [VR Math Shooter](https://github.com/Robin-qwerty/VR-math-game) - VR math game for Meta Quest 2. Written in Unity.
-* [VR-Wheelchair-Ping-Pong](https://github.com/PaulEdwardMurariu/VR-Wheelchair-Ping-Pong) - VR ping-pong game for wheelchair users. Written in Unity.
+* [VR Wheelchair Ping Pong](https://github.com/PaulEdwardMurariu/VR-Wheelchair-Ping-Pong) - VR ping-pong game for wheelchair users. Written in Unity.
 * [VR War Drum](https://github.com/kahogeoff/vr-war-drum) - VR rhythm game inspired by Taiko No Tatsujin and Taikojiro. Written in Unity.
 
 ## Others

--- a/README.md
+++ b/README.md
@@ -452,49 +452,49 @@ A selection of major game studios, publishers, etc.:
 
 ## VR
 
-* [RocketMan-a-VR-videogame-created-with-Unity](https://github.com/EliaFantini/RocketMan-a-VR-videogame-created-with-Unity) - Virtual reality escape-room-like game for Oculus Quest built with Unity.
-* [mern-vrgame](https://github.com/shamahoque/mern-vrgame) - MERN-stack VR game for the web. [Play it now!](http://vrgame2.mernbook.com)
-* [vr-war-drum](https://github.com/kahogeoff/vr-war-drum) - VR rhythm game inspired by Taiko No Tatsujin and Taikojiro.
+* [270Tetris](https://github.com/dschoeneborn/270Tetris) - VR take on classic Tetris.
+* [3D-Modeling-VR](https://github.com/mari-rmrz/3D-Modeling-VR) - Portfolio and development journal for a VR game project.
 * [adaptive-vr-game](https://github.com/PedroBarcha/adaptive-vr-game) - Educational Android VR game designed for people with neurodevelopmental disorders.
-* [Cindy-s-Bad-Luck-BLS-VR](https://github.com/ClaudiaRaffaelli/Cindy-s-Bad-Luck-BLS-VR) - VR game for learning basic life-support maneuvers.
-* [Terminal](https://github.com/danielcolinjames/Terminal) - Virtual reality puzzle game built in Unity.
 * [AbstractInvadersVR](https://github.com/guneyozsan/AbstractInvadersVR) - VR shooter created for Global Game Jam 2017.
 * [AirAttack](https://github.com/Vova-SH/AirAttack) - Gear VR game created for the 2018 VR 360 School Contest.
-* [The-Art-Inspector](https://github.com/chubozeko/The-Art-Inspector) - VR game about identifying and organizing real art pieces from fake ones.
-* [valentines-vr](https://github.com/urish/valentines-vr) - Small VR heart-collecting game built with A-Frame. [Play it now!](https://urish.github.io/valentines-vr/)
-* [Graveyard-Roller-Coaster](https://github.com/ShutovKS/Graveyard-Roller-Coaster) - Short cinematic VR roller-coaster game set in a graveyard.
-* [HandTracked-Virtual-Body-VR](https://github.com/YesItsSKM/HandTracked-Virtual-Body-VR) - VR game prototype focused on hand-tracked embodiment and IK body interaction.
-* [EcoHome](https://github.com/htl-leo-itp-2325-4-5BHITM/EcoHome) - Unity VR game about everyday sustainability. [Play it now!](https://ecohome.itch.io/ecohome)
-* [UMN-VR-Quest-2-App](https://github.com/UMN-VR/UMN-VR-Quest-2-App) - Open-sourced proof of concept for a photogrammetry-based Quest 2 VR experience.
-* [270Tetris](https://github.com/dschoeneborn/270Tetris) - VR take on classic Tetris.
-* [VR-math-game](https://github.com/Robin-qwerty/VR-math-game) - VR math game for Meta Quest 2.
-* [Dodge-Ball](https://github.com/SarathChandraKaza/Dodge-Ball) - Single-player dodgeball game for Oculus devices.
-* [invaderInVR](https://github.com/fgadea/invaderInVR) - Unity VR game inspired by classic Space Invaders.
-* [MarcoSmiles-RhythmGame](https://github.com/UmbertoDellaMonica/MarcoSmiles-RhythmGame) - VR rhythm platformer using Unity hand tracking and a FastAPI backend.
-* [pigpoppa](https://github.com/elocnatsirt/pigpoppa) - VR game created for Godot Wild Jam #22. [Play it now!](https://elocnat.itch.io/pigpoppa)
-* [king-of-kitchen](https://github.com/maxolib/king-of-kitchen) - VR kitchen game project.
-* [Mission_Impossible](https://github.com/Shawn0791/Mission_Impossible) - Giant-room-concept VR game. [Play it now!](https://shawnjobseeking.itch.io/mission-impossible-vr)
-* [Final-VR-Project](https://github.com/YesItsSKM/Final-VR-Project) - Final MSc VR/AR project.
-* [Modern-Cupid-VR](https://github.com/sarasmajic/Modern-Cupid-VR) - VR game built in Unity.
-* [CloudeLand-project](https://github.com/GigaFlopsis/CloudeLand-project) - CloudLand VR game for Daydream and Cardboard.
-* [CaveTerrors-VR](https://github.com/Z-ANESaber/CaveTerrors-VR) - Minecraft-inspired horror game with VR support.
 * [Arcadium](https://github.com/NeonVhenan/Arcadium) - VR app/game created as part of an MSc course.
 * [CatcherVRGame](https://github.com/nntdoan/CatcherVRGame) - VR game project.
-* [3D-Modeling-VR](https://github.com/mari-rmrz/3D-Modeling-VR) - Portfolio and development journal for a VR game project.
-* [Escape-the-Room](https://github.com/Cranesec/Escape-the-Room) - Immersive mystery VR escape-room game.
-* [VR-Wheelchair-Ping-Pong](https://github.com/PaulEdwardMurariu/VR-Wheelchair-Ping-Pong) - VR ping-pong game for wheelchair users.
-* [snowden](https://github.com/miozilla/snowden) - VR game project.
-* [vr-game](https://github.com/agrawalTanish/vr-game) - Interactive browser-based VR game experience with responsive UI and real-time interaction. [Play it now!](https://tanishvrgame.netlify.app/)
-* [Cuteness-Overdose-Vr](https://github.com/hendzormati/Cuteness-Overdose-Vr) - Meta Quest 3 VR game about smashing cupcakes in a shifting pastel-horror setting.
-* [mind-remnants](https://github.com/KatyaZubareva/mind-remnants) - VR game project.
-* [VR-AR-Game](https://github.com/alisatodorova/VR-AR-Game) - Unity game created for a virtual and augmented reality course.
-* [Tiny-Winter-Scare-VR](https://github.com/JeromeTDev/Tiny-Winter-Scare-VR) - Small VR jump-scare game built in Unity on Linux.
-* [MechaRacer](https://github.com/chubozeko/MechaRacer) - VR racing game about driving a toy car and hitting mech robots.
-* [Puzzle-Vault-Expedition](https://github.com/hxqqqqqqqq/Puzzle-Vault-Expedition) - Escape-room puzzle game project.
 * [cardboard](https://github.com/1j01/cardboard) - Early browser-based VR tunnel game experiment. [Play it now!](http://1j01.github.io/cardboard/)
+* [CaveTerrors-VR](https://github.com/Z-ANESaber/CaveTerrors-VR) - Minecraft-inspired horror game with VR support.
+* [Cindy-s-Bad-Luck-BLS-VR](https://github.com/ClaudiaRaffaelli/Cindy-s-Bad-Luck-BLS-VR) - VR game for learning basic life-support maneuvers.
+* [CloudeLand-project](https://github.com/GigaFlopsis/CloudeLand-project) - CloudLand VR game for Daydream and Cardboard.
+* [Cuteness-Overdose-Vr](https://github.com/hendzormati/Cuteness-Overdose-Vr) - Meta Quest 3 VR game about smashing cupcakes in a shifting pastel-horror setting.
+* [Dodge-Ball](https://github.com/SarathChandraKaza/Dodge-Ball) - Single-player dodgeball game for Oculus devices.
+* [EcoHome](https://github.com/htl-leo-itp-2325-4-5BHITM/EcoHome) - Unity VR game about everyday sustainability. [Play it now!](https://ecohome.itch.io/ecohome)
+* [Escape-the-Room](https://github.com/Cranesec/Escape-the-Room) - Immersive mystery VR escape-room game.
+* [Final-VR-Project](https://github.com/YesItsSKM/Final-VR-Project) - Final MSc VR/AR project.
 * [GodescXR](https://github.com/sorokivski/GodescXR) - VR game project. [Play it now!](https://sorokivski.itch.io/godescxr)
-* [vr-gardengame](https://github.com/faadil1999/vr-gardengame) - VR garden game project.
+* [Graveyard-Roller-Coaster](https://github.com/ShutovKS/Graveyard-Roller-Coaster) - Short cinematic VR roller-coaster game set in a graveyard.
+* [HandTracked-Virtual-Body-VR](https://github.com/YesItsSKM/HandTracked-Virtual-Body-VR) - VR game prototype focused on hand-tracked embodiment and IK body interaction.
+* [invaderInVR](https://github.com/fgadea/invaderInVR) - Unity VR game inspired by classic Space Invaders.
+* [king-of-kitchen](https://github.com/maxolib/king-of-kitchen) - VR kitchen game project.
+* [MarcoSmiles-RhythmGame](https://github.com/UmbertoDellaMonica/MarcoSmiles-RhythmGame) - VR rhythm platformer using Unity hand tracking and a FastAPI backend.
+* [MechaRacer](https://github.com/chubozeko/MechaRacer) - VR racing game about driving a toy car and hitting mech robots.
+* [mern-vrgame](https://github.com/shamahoque/mern-vrgame) - MERN-stack VR game for the web. [Play it now!](http://vrgame2.mernbook.com)
+* [mind-remnants](https://github.com/KatyaZubareva/mind-remnants) - VR game project.
+* [Mission_Impossible](https://github.com/Shawn0791/Mission_Impossible) - Giant-room-concept VR game. [Play it now!](https://shawnjobseeking.itch.io/mission-impossible-vr)
+* [Modern-Cupid-VR](https://github.com/sarasmajic/Modern-Cupid-VR) - VR game built in Unity.
+* [pigpoppa](https://github.com/elocnatsirt/pigpoppa) - VR game created for Godot Wild Jam #22. [Play it now!](https://elocnat.itch.io/pigpoppa)
+* [Puzzle-Vault-Expedition](https://github.com/hxqqqqqqqq/Puzzle-Vault-Expedition) - Escape-room puzzle game project.
+* [RocketMan-a-VR-videogame-created-with-Unity](https://github.com/EliaFantini/RocketMan-a-VR-videogame-created-with-Unity) - Virtual reality escape-room-like game for Oculus Quest built with Unity.
+* [snowden](https://github.com/miozilla/snowden) - VR game project.
+* [Terminal](https://github.com/danielcolinjames/Terminal) - Virtual reality puzzle game built in Unity.
+* [The-Art-Inspector](https://github.com/chubozeko/The-Art-Inspector) - VR game about identifying and organizing real art pieces from fake ones.
+* [Tiny-Winter-Scare-VR](https://github.com/JeromeTDev/Tiny-Winter-Scare-VR) - Small VR jump-scare game built in Unity on Linux.
+* [UMN-VR-Quest-2-App](https://github.com/UMN-VR/UMN-VR-Quest-2-App) - Open-sourced proof of concept for a photogrammetry-based Quest 2 VR experience.
+* [valentines-vr](https://github.com/urish/valentines-vr) - Small VR heart-collecting game built with A-Frame. [Play it now!](https://urish.github.io/valentines-vr/)
+* [VR-AR-Game](https://github.com/alisatodorova/VR-AR-Game) - Unity game created for a virtual and augmented reality course.
 * [VR-Escape-Room](https://github.com/AB-Pop/VR-Escape-Room) - Virtual escape-room project made for school.
+* [vr-game](https://github.com/agrawalTanish/vr-game) - Interactive browser-based VR game experience with responsive UI and real-time interaction. [Play it now!](https://tanishvrgame.netlify.app/)
+* [vr-gardengame](https://github.com/faadil1999/vr-gardengame) - VR garden game project.
+* [VR-math-game](https://github.com/Robin-qwerty/VR-math-game) - VR math game for Meta Quest 2.
+* [VR-Wheelchair-Ping-Pong](https://github.com/PaulEdwardMurariu/VR-Wheelchair-Ping-Pong) - VR ping-pong game for wheelchair users.
+* [vr-war-drum](https://github.com/kahogeoff/vr-war-drum) - VR rhythm game inspired by Taiko No Tatsujin and Taikojiro.
 
 ## Others
 

--- a/README.md
+++ b/README.md
@@ -452,9 +452,49 @@ A selection of major game studios, publishers, etc.:
 
 ## VR
 
+* [RocketMan-a-VR-videogame-created-with-Unity](https://github.com/EliaFantini/RocketMan-a-VR-videogame-created-with-Unity) - Virtual reality escape-room-like game for Oculus Quest built with Unity.
+* [mern-vrgame](https://github.com/shamahoque/mern-vrgame) - MERN-stack VR game for the web. [Play it now!](http://vrgame2.mernbook.com)
+* [vr-war-drum](https://github.com/kahogeoff/vr-war-drum) - VR rhythm game inspired by Taiko No Tatsujin and Taikojiro.
+* [adaptive-vr-game](https://github.com/PedroBarcha/adaptive-vr-game) - Educational Android VR game designed for people with neurodevelopmental disorders.
+* [Cindy-s-Bad-Luck-BLS-VR](https://github.com/ClaudiaRaffaelli/Cindy-s-Bad-Luck-BLS-VR) - VR game for learning basic life-support maneuvers.
+* [Terminal](https://github.com/danielcolinjames/Terminal) - Virtual reality puzzle game built in Unity.
 * [AbstractInvadersVR](https://github.com/guneyozsan/AbstractInvadersVR) - VR shooter created for Global Game Jam 2017.
-* [ergo](https://github.com/alvinwan/ergo) - Endless runner game in virtual reality. [Play it now!](https://alvinwan.com/ergo)
-* [vin-carnival](https://github.com/computationalcore/vin-carnival) - Non-profit open-source virtual reality game made with Unity 3D and GoogleVR.
+* [AirAttack](https://github.com/Vova-SH/AirAttack) - Gear VR game created for the 2018 VR 360 School Contest.
+* [The-Art-Inspector](https://github.com/chubozeko/The-Art-Inspector) - VR game about identifying and organizing real art pieces from fake ones.
+* [valentines-vr](https://github.com/urish/valentines-vr) - Small VR heart-collecting game built with A-Frame. [Play it now!](https://urish.github.io/valentines-vr/)
+* [Graveyard-Roller-Coaster](https://github.com/ShutovKS/Graveyard-Roller-Coaster) - Short cinematic VR roller-coaster game set in a graveyard.
+* [HandTracked-Virtual-Body-VR](https://github.com/YesItsSKM/HandTracked-Virtual-Body-VR) - VR game prototype focused on hand-tracked embodiment and IK body interaction.
+* [EcoHome](https://github.com/htl-leo-itp-2325-4-5BHITM/EcoHome) - Unity VR game about everyday sustainability. [Play it now!](https://ecohome.itch.io/ecohome)
+* [UMN-VR-Quest-2-App](https://github.com/UMN-VR/UMN-VR-Quest-2-App) - Open-sourced proof of concept for a photogrammetry-based Quest 2 VR experience.
+* [270Tetris](https://github.com/dschoeneborn/270Tetris) - VR take on classic Tetris.
+* [VR-math-game](https://github.com/Robin-qwerty/VR-math-game) - VR math game for Meta Quest 2.
+* [Dodge-Ball](https://github.com/SarathChandraKaza/Dodge-Ball) - Single-player dodgeball game for Oculus devices.
+* [invaderInVR](https://github.com/fgadea/invaderInVR) - Unity VR game inspired by classic Space Invaders.
+* [MarcoSmiles-RhythmGame](https://github.com/UmbertoDellaMonica/MarcoSmiles-RhythmGame) - VR rhythm platformer using Unity hand tracking and a FastAPI backend.
+* [pigpoppa](https://github.com/elocnatsirt/pigpoppa) - VR game created for Godot Wild Jam #22. [Play it now!](https://elocnat.itch.io/pigpoppa)
+* [king-of-kitchen](https://github.com/maxolib/king-of-kitchen) - VR kitchen game project.
+* [Mission_Impossible](https://github.com/Shawn0791/Mission_Impossible) - Giant-room-concept VR game. [Play it now!](https://shawnjobseeking.itch.io/mission-impossible-vr)
+* [Final-VR-Project](https://github.com/YesItsSKM/Final-VR-Project) - Final MSc VR/AR project.
+* [Modern-Cupid-VR](https://github.com/sarasmajic/Modern-Cupid-VR) - VR game built in Unity.
+* [CloudeLand-project](https://github.com/GigaFlopsis/CloudeLand-project) - CloudLand VR game for Daydream and Cardboard.
+* [CaveTerrors-VR](https://github.com/Z-ANESaber/CaveTerrors-VR) - Minecraft-inspired horror game with VR support.
+* [Arcadium](https://github.com/NeonVhenan/Arcadium) - VR app/game created as part of an MSc course.
+* [CatcherVRGame](https://github.com/nntdoan/CatcherVRGame) - VR game project.
+* [3D-Modeling-VR](https://github.com/mari-rmrz/3D-Modeling-VR) - Portfolio and development journal for a VR game project.
+* [Escape-the-Room](https://github.com/Cranesec/Escape-the-Room) - Immersive mystery VR escape-room game.
+* [VR-Wheelchair-Ping-Pong](https://github.com/PaulEdwardMurariu/VR-Wheelchair-Ping-Pong) - VR ping-pong game for wheelchair users.
+* [snowden](https://github.com/miozilla/snowden) - VR game project.
+* [vr-game](https://github.com/agrawalTanish/vr-game) - Interactive browser-based VR game experience with responsive UI and real-time interaction. [Play it now!](https://tanishvrgame.netlify.app/)
+* [Cuteness-Overdose-Vr](https://github.com/hendzormati/Cuteness-Overdose-Vr) - Meta Quest 3 VR game about smashing cupcakes in a shifting pastel-horror setting.
+* [mind-remnants](https://github.com/KatyaZubareva/mind-remnants) - VR game project.
+* [VR-AR-Game](https://github.com/alisatodorova/VR-AR-Game) - Unity game created for a virtual and augmented reality course.
+* [Tiny-Winter-Scare-VR](https://github.com/JeromeTDev/Tiny-Winter-Scare-VR) - Small VR jump-scare game built in Unity on Linux.
+* [MechaRacer](https://github.com/chubozeko/MechaRacer) - VR racing game about driving a toy car and hitting mech robots.
+* [Puzzle-Vault-Expedition](https://github.com/hxqqqqqqqq/Puzzle-Vault-Expedition) - Escape-room puzzle game project.
+* [cardboard](https://github.com/1j01/cardboard) - Early browser-based VR tunnel game experiment. [Play it now!](http://1j01.github.io/cardboard/)
+* [GodescXR](https://github.com/sorokivski/GodescXR) - VR game project. [Play it now!](https://sorokivski.itch.io/godescxr)
+* [vr-gardengame](https://github.com/faadil1999/vr-gardengame) - VR garden game project.
+* [VR-Escape-Room](https://github.com/AB-Pop/VR-Escape-Room) - Virtual escape-room project made for school.
 
 ## Others
 

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ A selection of major game studios, publishers, etc.:
 * [Abstract Invaders VR](https://github.com/guneyozsan/AbstractInvadersVR) - VR shooter created for Global Game Jam 2017. Written in Unity.
 * [AirAttack](https://github.com/Vova-SH/AirAttack) - Gear VR game created for the 2018 VR 360 School Contest. Written in Unity.
 * [Arcadium](https://github.com/NeonVhenan/Arcadium) - VR app/game created as part of an MSc course. Written in Unity.
-* [CatcherVRGame](https://github.com/nntdoan/CatcherVRGame) - VR game project. Written in Unity.
+* [TrashCatcher](https://github.com/nntdoan/CatcherVRGame) - VR game project. Written in Unity.
 * [cardboard](https://github.com/1j01/cardboard) - Early browser-based VR tunnel game experiment. Written in HTML/JavaScript. [Play it now!](http://1j01.github.io/cardboard/)
 * [CaveTerrors-VR](https://github.com/Z-ANESaber/CaveTerrors-VR) - Minecraft-inspired horror game with VR support. Written in Unity.
 * [Cindy's Bad Luck](https://github.com/ClaudiaRaffaelli/Cindy-s-Bad-Luck-BLS-VR) - VR game for learning basic life-support maneuvers. Written in Unity.
@@ -487,7 +487,7 @@ A selection of major game studios, publishers, etc.:
 * [Tiny Winter Scare VR](https://github.com/JeromeTDev/Tiny-Winter-Scare-VR) - Small VR jump-scare game built in Unity on Linux. Written in Unity.
 * [UMN VR Quest 2 Photogrammetry Demo](https://github.com/UMN-VR/UMN-VR-Quest-2-App) - Open-sourced proof of concept for a photogrammetry-based Quest 2 VR experience. Written in Unity and WebXR. [Play it now!](https://umn-vr.github.io/WebGL_Demo/)
 * [VORD](https://github.com/urish/valentines-vr) - Small VR heart-collecting game built with A-Frame. Written in A-Frame. [Play it now!](https://urish.github.io/valentines-vr/)
-* [VR AR Game](https://github.com/alisatodorova/VR-AR-Game) - Unity game created for a virtual and augmented reality course. Written in Unity.
+* [VR-AR-Game](https://github.com/alisatodorova/VR-AR-Game) - Unity game created for a virtual and augmented reality course. Written in Unity.
 * [VR Escape Room](https://github.com/AB-Pop/VR-Escape-Room) - Virtual escape-room project made for school. Written in Unity.
 * [VR Game](https://github.com/agrawalTanish/vr-game) - Interactive browser-based VR game experience with responsive UI and real-time interaction. Written in HTML/JavaScript. [Play it now!](https://tanishvrgame.netlify.app/)
 * [vr-gardengame](https://github.com/faadil1999/vr-gardengame) - VR garden game project. Written in Unity.

--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ A selection of major game studios, publishers, etc.:
 * [Terminal](https://github.com/danielcolinjames/Terminal) - Virtual reality puzzle game built in Unity.
 * [The-Art-Inspector](https://github.com/chubozeko/The-Art-Inspector) - VR game about identifying and organizing real art pieces from fake ones.
 * [Tiny-Winter-Scare-VR](https://github.com/JeromeTDev/Tiny-Winter-Scare-VR) - Small VR jump-scare game built in Unity on Linux.
-* [UMN-VR-Quest-2-App](https://github.com/UMN-VR/UMN-VR-Quest-2-App) - Open-sourced proof of concept for a photogrammetry-based Quest 2 VR experience.
+* [UMN-VR-Quest-2-App](https://github.com/UMN-VR/UMN-VR-Quest-2-App) - Open-sourced proof of concept for a photogrammetry-based Quest 2 VR experience. [Play it now!](https://umn-vr.github.io/WebGL_Demo/)
 * [valentines-vr](https://github.com/urish/valentines-vr) - Small VR heart-collecting game built with A-Frame. [Play it now!](https://urish.github.io/valentines-vr/)
 * [VR-AR-Game](https://github.com/alisatodorova/VR-AR-Game) - Unity game created for a virtual and augmented reality course.
 * [VR-Escape-Room](https://github.com/AB-Pop/VR-Escape-Room) - Virtual escape-room project made for school.

--- a/README.md
+++ b/README.md
@@ -452,48 +452,18 @@ A selection of major game studios, publishers, etc.:
 
 ## VR
 
-* [270Tetris](https://github.com/dschoeneborn/270Tetris) - VR take on classic Tetris.
-* [3D-Modeling-VR](https://github.com/mari-rmrz/3D-Modeling-VR) - Portfolio and development journal for a VR game project.
 * [adaptive-vr-game](https://github.com/PedroBarcha/adaptive-vr-game) - Educational Android VR game designed for people with neurodevelopmental disorders.
 * [AbstractInvadersVR](https://github.com/guneyozsan/AbstractInvadersVR) - VR shooter created for Global Game Jam 2017.
-* [AirAttack](https://github.com/Vova-SH/AirAttack) - Gear VR game created for the 2018 VR 360 School Contest.
-* [Arcadium](https://github.com/NeonVhenan/Arcadium) - VR app/game created as part of an MSc course.
-* [CatcherVRGame](https://github.com/nntdoan/CatcherVRGame) - VR game project.
-* [cardboard](https://github.com/1j01/cardboard) - Early browser-based VR tunnel game experiment. [Play it now!](http://1j01.github.io/cardboard/)
 * [CaveTerrors-VR](https://github.com/Z-ANESaber/CaveTerrors-VR) - Minecraft-inspired horror game with VR support.
 * [Cindy-s-Bad-Luck-BLS-VR](https://github.com/ClaudiaRaffaelli/Cindy-s-Bad-Luck-BLS-VR) - VR game for learning basic life-support maneuvers.
-* [CloudeLand-project](https://github.com/GigaFlopsis/CloudeLand-project) - CloudLand VR game for Daydream and Cardboard.
-* [Cuteness-Overdose-Vr](https://github.com/hendzormati/Cuteness-Overdose-Vr) - Meta Quest 3 VR game about smashing cupcakes in a shifting pastel-horror setting.
-* [Dodge-Ball](https://github.com/SarathChandraKaza/Dodge-Ball) - Single-player dodgeball game for Oculus devices.
 * [EcoHome](https://github.com/htl-leo-itp-2325-4-5BHITM/EcoHome) - Unity VR game about everyday sustainability. [Play it now!](https://ecohome.itch.io/ecohome)
-* [Escape-the-Room](https://github.com/Cranesec/Escape-the-Room) - Immersive mystery VR escape-room game.
-* [Final-VR-Project](https://github.com/YesItsSKM/Final-VR-Project) - Final MSc VR/AR project.
-* [GodescXR](https://github.com/sorokivski/GodescXR) - VR game project. [Play it now!](https://sorokivski.itch.io/godescxr)
 * [Graveyard-Roller-Coaster](https://github.com/ShutovKS/Graveyard-Roller-Coaster) - Short cinematic VR roller-coaster game set in a graveyard.
-* [HandTracked-Virtual-Body-VR](https://github.com/YesItsSKM/HandTracked-Virtual-Body-VR) - VR game prototype focused on hand-tracked embodiment and IK body interaction.
 * [invaderInVR](https://github.com/fgadea/invaderInVR) - Unity VR game inspired by classic Space Invaders.
-* [king-of-kitchen](https://github.com/maxolib/king-of-kitchen) - VR kitchen game project.
 * [MarcoSmiles-RhythmGame](https://github.com/UmbertoDellaMonica/MarcoSmiles-RhythmGame) - VR rhythm platformer using Unity hand tracking and a FastAPI backend.
 * [MechaRacer](https://github.com/chubozeko/MechaRacer) - VR racing game about driving a toy car and hitting mech robots.
 * [mern-vrgame](https://github.com/shamahoque/mern-vrgame) - MERN-stack VR game for the web. [Play it now!](http://vrgame2.mernbook.com)
-* [mind-remnants](https://github.com/KatyaZubareva/mind-remnants) - VR game project.
-* [Mission_Impossible](https://github.com/Shawn0791/Mission_Impossible) - Giant-room-concept VR game. [Play it now!](https://shawnjobseeking.itch.io/mission-impossible-vr)
-* [Modern-Cupid-VR](https://github.com/sarasmajic/Modern-Cupid-VR) - VR game built in Unity.
-* [pigpoppa](https://github.com/elocnatsirt/pigpoppa) - VR game created for Godot Wild Jam #22. [Play it now!](https://elocnat.itch.io/pigpoppa)
-* [Puzzle-Vault-Expedition](https://github.com/hxqqqqqqqq/Puzzle-Vault-Expedition) - Escape-room puzzle game project.
-* [RocketMan-a-VR-videogame-created-with-Unity](https://github.com/EliaFantini/RocketMan-a-VR-videogame-created-with-Unity) - Virtual reality escape-room-like game for Oculus Quest built with Unity.
-* [snowden](https://github.com/miozilla/snowden) - VR game project.
-* [Terminal](https://github.com/danielcolinjames/Terminal) - Virtual reality puzzle game built in Unity.
 * [The-Art-Inspector](https://github.com/chubozeko/The-Art-Inspector) - VR game about identifying and organizing real art pieces from fake ones.
 * [Tiny-Winter-Scare-VR](https://github.com/JeromeTDev/Tiny-Winter-Scare-VR) - Small VR jump-scare game built in Unity on Linux.
-* [UMN-VR-Quest-2-App](https://github.com/UMN-VR/UMN-VR-Quest-2-App) - Open-sourced proof of concept for a photogrammetry-based Quest 2 VR experience.
-* [valentines-vr](https://github.com/urish/valentines-vr) - Small VR heart-collecting game built with A-Frame. [Play it now!](https://urish.github.io/valentines-vr/)
-* [VR-AR-Game](https://github.com/alisatodorova/VR-AR-Game) - Unity game created for a virtual and augmented reality course.
-* [VR-Escape-Room](https://github.com/AB-Pop/VR-Escape-Room) - Virtual escape-room project made for school.
-* [vr-game](https://github.com/agrawalTanish/vr-game) - Interactive browser-based VR game experience with responsive UI and real-time interaction. [Play it now!](https://tanishvrgame.netlify.app/)
-* [vr-gardengame](https://github.com/faadil1999/vr-gardengame) - VR garden game project.
-* [VR-math-game](https://github.com/Robin-qwerty/VR-math-game) - VR math game for Meta Quest 2.
-* [VR-Wheelchair-Ping-Pong](https://github.com/PaulEdwardMurariu/VR-Wheelchair-Ping-Pong) - VR ping-pong game for wheelchair users.
 * [vr-war-drum](https://github.com/kahogeoff/vr-war-drum) - VR rhythm game inspired by Taiko No Tatsujin and Taikojiro.
 
 ## Others

--- a/README.md
+++ b/README.md
@@ -452,49 +452,49 @@ A selection of major game studios, publishers, etc.:
 
 ## VR
 
-* [270Tetris](https://github.com/dschoeneborn/270Tetris) - VR take on classic Tetris.
-* [3D-Modeling-VR](https://github.com/mari-rmrz/3D-Modeling-VR) - Portfolio and development journal for a VR game project.
-* [adaptive-vr-game](https://github.com/PedroBarcha/adaptive-vr-game) - Educational Android VR game designed for people with neurodevelopmental disorders.
-* [AbstractInvadersVR](https://github.com/guneyozsan/AbstractInvadersVR) - VR shooter created for Global Game Jam 2017.
-* [AirAttack](https://github.com/Vova-SH/AirAttack) - Gear VR game created for the 2018 VR 360 School Contest.
-* [Arcadium](https://github.com/NeonVhenan/Arcadium) - VR app/game created as part of an MSc course.
-* [CatcherVRGame](https://github.com/nntdoan/CatcherVRGame) - VR game project.
-* [cardboard](https://github.com/1j01/cardboard) - Early browser-based VR tunnel game experiment. [Play it now!](http://1j01.github.io/cardboard/)
-* [CaveTerrors-VR](https://github.com/Z-ANESaber/CaveTerrors-VR) - Minecraft-inspired horror game with VR support.
-* [Cindy-s-Bad-Luck-BLS-VR](https://github.com/ClaudiaRaffaelli/Cindy-s-Bad-Luck-BLS-VR) - VR game for learning basic life-support maneuvers.
-* [CloudeLand-project](https://github.com/GigaFlopsis/CloudeLand-project) - CloudLand VR game for Daydream and Cardboard.
-* [Cuteness-Overdose-Vr](https://github.com/hendzormati/Cuteness-Overdose-Vr) - Meta Quest 3 VR game about smashing cupcakes in a shifting pastel-horror setting.
-* [Dodge-Ball](https://github.com/SarathChandraKaza/Dodge-Ball) - Single-player dodgeball game for Oculus devices.
-* [EcoHome](https://github.com/htl-leo-itp-2325-4-5BHITM/EcoHome) - Unity VR game about everyday sustainability. [Play it now!](https://ecohome.itch.io/ecohome)
-* [Escape-the-Room](https://github.com/Cranesec/Escape-the-Room) - Immersive mystery VR escape-room game.
-* [Final-VR-Project](https://github.com/YesItsSKM/Final-VR-Project) - Final MSc VR/AR project.
-* [GodescXR](https://github.com/sorokivski/GodescXR) - VR game project. [Play it now!](https://sorokivski.itch.io/godescxr)
-* [Graveyard-Roller-Coaster](https://github.com/ShutovKS/Graveyard-Roller-Coaster) - Short cinematic VR roller-coaster game set in a graveyard.
-* [HandTracked-Virtual-Body-VR](https://github.com/YesItsSKM/HandTracked-Virtual-Body-VR) - VR game prototype focused on hand-tracked embodiment and IK body interaction.
-* [invaderInVR](https://github.com/fgadea/invaderInVR) - Unity VR game inspired by classic Space Invaders.
-* [king-of-kitchen](https://github.com/maxolib/king-of-kitchen) - VR kitchen game project.
-* [MarcoSmiles-RhythmGame](https://github.com/UmbertoDellaMonica/MarcoSmiles-RhythmGame) - VR rhythm platformer using Unity hand tracking and a FastAPI backend.
-* [MechaRacer](https://github.com/chubozeko/MechaRacer) - VR racing game about driving a toy car and hitting mech robots.
-* [mern-vrgame](https://github.com/shamahoque/mern-vrgame) - MERN-stack VR game for the web. [Play it now!](http://vrgame2.mernbook.com)
-* [mind-remnants](https://github.com/KatyaZubareva/mind-remnants) - VR game project.
-* [Mission_Impossible](https://github.com/Shawn0791/Mission_Impossible) - Giant-room-concept VR game. [Play it now!](https://shawnjobseeking.itch.io/mission-impossible-vr)
-* [Modern-Cupid-VR](https://github.com/sarasmajic/Modern-Cupid-VR) - VR game built in Unity.
-* [pigpoppa](https://github.com/elocnatsirt/pigpoppa) - VR game created for Godot Wild Jam #22. [Play it now!](https://elocnat.itch.io/pigpoppa)
-* [Puzzle-Vault-Expedition](https://github.com/hxqqqqqqqq/Puzzle-Vault-Expedition) - Escape-room puzzle game project.
-* [RocketMan-a-VR-videogame-created-with-Unity](https://github.com/EliaFantini/RocketMan-a-VR-videogame-created-with-Unity) - Virtual reality escape-room-like game for Oculus Quest built with Unity.
-* [snowden](https://github.com/miozilla/snowden) - VR game project.
-* [Terminal](https://github.com/danielcolinjames/Terminal) - Virtual reality puzzle game built in Unity.
-* [The-Art-Inspector](https://github.com/chubozeko/The-Art-Inspector) - VR game about identifying and organizing real art pieces from fake ones.
-* [Tiny-Winter-Scare-VR](https://github.com/JeromeTDev/Tiny-Winter-Scare-VR) - Small VR jump-scare game built in Unity on Linux.
-* [UMN-VR-Quest-2-App](https://github.com/UMN-VR/UMN-VR-Quest-2-App) - Open-sourced proof of concept for a photogrammetry-based Quest 2 VR experience. [Play it now!](https://umn-vr.github.io/WebGL_Demo/)
-* [valentines-vr](https://github.com/urish/valentines-vr) - Small VR heart-collecting game built with A-Frame. [Play it now!](https://urish.github.io/valentines-vr/)
-* [VR-AR-Game](https://github.com/alisatodorova/VR-AR-Game) - Unity game created for a virtual and augmented reality course.
-* [VR-Escape-Room](https://github.com/AB-Pop/VR-Escape-Room) - Virtual escape-room project made for school.
-* [vr-game](https://github.com/agrawalTanish/vr-game) - Interactive browser-based VR game experience with responsive UI and real-time interaction. [Play it now!](https://tanishvrgame.netlify.app/)
-* [vr-gardengame](https://github.com/faadil1999/vr-gardengame) - VR garden game project.
-* [VR-math-game](https://github.com/Robin-qwerty/VR-math-game) - VR math game for Meta Quest 2.
-* [VR-Wheelchair-Ping-Pong](https://github.com/PaulEdwardMurariu/VR-Wheelchair-Ping-Pong) - VR ping-pong game for wheelchair users.
-* [vr-war-drum](https://github.com/kahogeoff/vr-war-drum) - VR rhythm game inspired by Taiko No Tatsujin and Taikojiro.
+* [270Tetris](https://github.com/dschoeneborn/270Tetris) - VR take on classic Tetris. Written in Unity.
+* [3D-Modeling-VR](https://github.com/mari-rmrz/3D-Modeling-VR) - Portfolio and development journal for a VR game project. Written in Unity.
+* [adaptive-vr-game](https://github.com/PedroBarcha/adaptive-vr-game) - Educational Android VR game designed for people with neurodevelopmental disorders. Written in Unity.
+* [AbstractInvadersVR](https://github.com/guneyozsan/AbstractInvadersVR) - VR shooter created for Global Game Jam 2017. Written in Unity.
+* [AirAttack](https://github.com/Vova-SH/AirAttack) - Gear VR game created for the 2018 VR 360 School Contest. Written in Unity.
+* [Arcadium](https://github.com/NeonVhenan/Arcadium) - VR app/game created as part of an MSc course. Written in Unity.
+* [CatcherVRGame](https://github.com/nntdoan/CatcherVRGame) - VR game project. Written in C#.
+* [cardboard](https://github.com/1j01/cardboard) - Early browser-based VR tunnel game experiment. Written in HTML/JavaScript. [Play it now!](http://1j01.github.io/cardboard/)
+* [CaveTerrors-VR](https://github.com/Z-ANESaber/CaveTerrors-VR) - Minecraft-inspired horror game with VR support. Written in Unity.
+* [Cindy-s-Bad-Luck-BLS-VR](https://github.com/ClaudiaRaffaelli/Cindy-s-Bad-Luck-BLS-VR) - VR game for learning basic life-support maneuvers. Written in Unity.
+* [CloudeLand-project](https://github.com/GigaFlopsis/CloudeLand-project) - CloudLand VR game for Daydream and Cardboard. Written in Unity.
+* [Cuteness-Overdose-Vr](https://github.com/hendzormati/Cuteness-Overdose-Vr) - Meta Quest 3 VR game about smashing cupcakes in a shifting pastel-horror setting. Written in Unity.
+* [Dodge-Ball](https://github.com/SarathChandraKaza/Dodge-Ball) - Single-player dodgeball game for Oculus devices. Written in C#.
+* [EcoHome](https://github.com/htl-leo-itp-2325-4-5BHITM/EcoHome) - Unity VR game about everyday sustainability. Written in Unity. [Play it now!](https://ecohome.itch.io/ecohome)
+* [Escape-the-Room](https://github.com/Cranesec/Escape-the-Room) - Immersive mystery VR escape-room game. Written in Python.
+* [Final-VR-Project](https://github.com/YesItsSKM/Final-VR-Project) - Final MSc VR/AR project. Written in Unity.
+* [GodescXR](https://github.com/sorokivski/GodescXR) - VR game project. Written in Godot. [Play it now!](https://sorokivski.itch.io/godescxr)
+* [Graveyard-Roller-Coaster](https://github.com/ShutovKS/Graveyard-Roller-Coaster) - Short cinematic VR roller-coaster game set in a graveyard. Written in Unity.
+* [HandTracked-Virtual-Body-VR](https://github.com/YesItsSKM/HandTracked-Virtual-Body-VR) - VR game prototype focused on hand-tracked embodiment and IK body interaction. Written in Unity.
+* [invaderInVR](https://github.com/fgadea/invaderInVR) - Unity VR game inspired by classic Space Invaders. Written in Unity.
+* [king-of-kitchen](https://github.com/maxolib/king-of-kitchen) - VR kitchen game project. Written in Unity.
+* [MarcoSmiles-RhythmGame](https://github.com/UmbertoDellaMonica/MarcoSmiles-RhythmGame) - VR rhythm platformer using Unity hand tracking and a FastAPI backend. Written in Unity and FastAPI.
+* [MechaRacer](https://github.com/chubozeko/MechaRacer) - VR racing game about driving a toy car and hitting mech robots. Written in Unity.
+* [mern-vrgame](https://github.com/shamahoque/mern-vrgame) - MERN-stack VR game for the web. Written in JavaScript (MERN). [Play it now!](http://vrgame2.mernbook.com)
+* [mind-remnants](https://github.com/KatyaZubareva/mind-remnants) - VR game project. Written in Unity.
+* [Mission_Impossible](https://github.com/Shawn0791/Mission_Impossible) - Giant-room-concept VR game. Written in Unity. [Play it now!](https://shawnjobseeking.itch.io/mission-impossible-vr)
+* [Modern-Cupid-VR](https://github.com/sarasmajic/Modern-Cupid-VR) - VR game built in Unity. Written in Unity.
+* [pigpoppa](https://github.com/elocnatsirt/pigpoppa) - VR game created for Godot Wild Jam #22. Written in Godot. [Play it now!](https://elocnat.itch.io/pigpoppa)
+* [Puzzle-Vault-Expedition](https://github.com/hxqqqqqqqq/Puzzle-Vault-Expedition) - Escape-room puzzle game project. Written in web technologies.
+* [RocketMan-a-VR-videogame-created-with-Unity](https://github.com/EliaFantini/RocketMan-a-VR-videogame-created-with-Unity) - Virtual reality escape-room-like game for Oculus Quest built with Unity. Written in Unity.
+* [snowden](https://github.com/miozilla/snowden) - VR game project. Written in SQL.
+* [Terminal](https://github.com/danielcolinjames/Terminal) - Virtual reality puzzle game built in Unity. Written in Unity.
+* [The-Art-Inspector](https://github.com/chubozeko/The-Art-Inspector) - VR game about identifying and organizing real art pieces from fake ones. Written in Unity.
+* [Tiny-Winter-Scare-VR](https://github.com/JeromeTDev/Tiny-Winter-Scare-VR) - Small VR jump-scare game built in Unity on Linux. Written in Unity.
+* [UMN-VR-Quest-2-App](https://github.com/UMN-VR/UMN-VR-Quest-2-App) - Open-sourced proof of concept for a photogrammetry-based Quest 2 VR experience. Written in Unity and WebXR. [Play it now!](https://umn-vr.github.io/WebGL_Demo/)
+* [valentines-vr](https://github.com/urish/valentines-vr) - Small VR heart-collecting game built with A-Frame. Written in A-Frame. [Play it now!](https://urish.github.io/valentines-vr/)
+* [VR-AR-Game](https://github.com/alisatodorova/VR-AR-Game) - Unity game created for a virtual and augmented reality course. Written in Unity.
+* [VR-Escape-Room](https://github.com/AB-Pop/VR-Escape-Room) - Virtual escape-room project made for school. Written in Unity.
+* [vr-game](https://github.com/agrawalTanish/vr-game) - Interactive browser-based VR game experience with responsive UI and real-time interaction. Written in HTML/JavaScript. [Play it now!](https://tanishvrgame.netlify.app/)
+* [vr-gardengame](https://github.com/faadil1999/vr-gardengame) - VR garden game project. Written in Unity.
+* [VR-math-game](https://github.com/Robin-qwerty/VR-math-game) - VR math game for Meta Quest 2. Written in Unity.
+* [VR-Wheelchair-Ping-Pong](https://github.com/PaulEdwardMurariu/VR-Wheelchair-Ping-Pong) - VR ping-pong game for wheelchair users. Written in Unity.
+* [vr-war-drum](https://github.com/kahogeoff/vr-war-drum) - VR rhythm game inspired by Taiko No Tatsujin and Taikojiro. Written in Unity.
 
 ## Others
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Help: [MarkDown Help](https://help.github.com/articles/github-flavored-markdown)
   - [Sandbox](#user-content-sandbox-1)
   - [Simulation](#simulation)
   - [Strategy](#user-content-strategy-1)
+  - [VR](#user-content-vr)
 - [Mobile Games](#user-content-mobile-games)
   - [Android](#user-content-android)
   - [IOS](#user-content-ios)
@@ -448,6 +449,12 @@ A selection of major game studios, publishers, etc.:
 * [Warzone 2100](https://github.com/Warzone2100/warzone2100) - Postnuclear realtime strategy.
 * [Wyrmsun](https://github.com/andrettin/wyrmsun) - Strategy game based on history, mythology and fiction.
 * [Zero-K](https://github.com/ZeroK-RTS/Zero-K) - Open source RTS game with physical projectiles and smart units.
+
+## VR
+
+* [AbstractInvadersVR](https://github.com/guneyozsan/AbstractInvadersVR) - VR shooter created for Global Game Jam 2017.
+* [ergo](https://github.com/alvinwan/ergo) - Endless runner game in virtual reality. [Play it now!](https://alvinwan.com/ergo)
+* [vin-carnival](https://github.com/computationalcore/vin-carnival) - Non-profit open-source virtual reality game made with Unity 3D and GoogleVR.
 
 ## Others
 

--- a/README.md
+++ b/README.md
@@ -458,13 +458,13 @@ A selection of major game studios, publishers, etc.:
 * [AbstractInvadersVR](https://github.com/guneyozsan/AbstractInvadersVR) - VR shooter created for Global Game Jam 2017. Written in Unity.
 * [AirAttack](https://github.com/Vova-SH/AirAttack) - Gear VR game created for the 2018 VR 360 School Contest. Written in Unity.
 * [Arcadium](https://github.com/NeonVhenan/Arcadium) - VR app/game created as part of an MSc course. Written in Unity.
-* [CatcherVRGame](https://github.com/nntdoan/CatcherVRGame) - VR game project. Written in C#.
+* [CatcherVRGame](https://github.com/nntdoan/CatcherVRGame) - VR game project. Written in Unity.
 * [cardboard](https://github.com/1j01/cardboard) - Early browser-based VR tunnel game experiment. Written in HTML/JavaScript. [Play it now!](http://1j01.github.io/cardboard/)
 * [CaveTerrors-VR](https://github.com/Z-ANESaber/CaveTerrors-VR) - Minecraft-inspired horror game with VR support. Written in Unity.
 * [Cindy-s-Bad-Luck-BLS-VR](https://github.com/ClaudiaRaffaelli/Cindy-s-Bad-Luck-BLS-VR) - VR game for learning basic life-support maneuvers. Written in Unity.
 * [CloudeLand-project](https://github.com/GigaFlopsis/CloudeLand-project) - CloudLand VR game for Daydream and Cardboard. Written in Unity.
 * [Cuteness-Overdose-Vr](https://github.com/hendzormati/Cuteness-Overdose-Vr) - Meta Quest 3 VR game about smashing cupcakes in a shifting pastel-horror setting. Written in Unity.
-* [Dodge-Ball](https://github.com/SarathChandraKaza/Dodge-Ball) - Single-player dodgeball game for Oculus devices. Written in C#.
+* [Dodge-Ball](https://github.com/SarathChandraKaza/Dodge-Ball) - Single-player dodgeball game for Oculus devices. Written in Unity.
 * [EcoHome](https://github.com/htl-leo-itp-2325-4-5BHITM/EcoHome) - Unity VR game about everyday sustainability. Written in Unity. [Play it now!](https://ecohome.itch.io/ecohome)
 * [Escape-the-Room](https://github.com/Cranesec/Escape-the-Room) - Immersive mystery VR escape-room game. Written in Python.
 * [Final-VR-Project](https://github.com/YesItsSKM/Final-VR-Project) - Final MSc VR/AR project. Written in Unity.


### PR DESCRIPTION
Adds a new VR subsection under Native with verified open-source VR games from the GitHub vr-game topic.

I checked each candidate in the MR for whether it is actually a game, whether source code is present, and whether there is a clear open-source signal (license or explicit open-source indication). I also kept only confirmed playable links.

Closes #40.